### PR TITLE
get_input not available for plugins

### DIFF
--- a/lib/ripl/history.rb
+++ b/lib/ripl/history.rb
@@ -3,7 +3,13 @@ module Ripl::History
     @history_file ||= File.expand_path(config[:history])
   end
 
-  def history; @history; end
+  def history
+   if config[:readline]
+     Readline::HISTORY
+   else
+     @history
+   end
+  end
 
   def get_input
     (@history << super)[-1]

--- a/lib/ripl/readline.rb
+++ b/lib/ripl/readline.rb
@@ -1,9 +1,0 @@
-require 'readline'
-module Ripl::Readline
-  def get_input
-    Readline.readline prompt, true
-  end
-
-  def history; Readline::HISTORY; end
-end
-Ripl::Shell.send :include, Ripl::Readline

--- a/lib/ripl/shell.rb
+++ b/lib/ripl/shell.rb
@@ -3,7 +3,7 @@ class Ripl::Shell
     :binding=>TOPLEVEL_BINDING, :irbrc=>'~/.irbrc'}
 
   def self.create(options={})
-    require 'ripl/readline' if options[:readline]
+    require 'readline' if options[:readline]
     require 'ripl/completion'
     new(options)
   rescue LoadError
@@ -63,8 +63,12 @@ class Ripl::Shell
 
     # @return [String, nil] Prints #prompt and returns input given by user
     def get_input
-      print prompt
-      $stdin.gets.chomp
+      if config[:readline]
+        Readline.readline prompt, true
+      else
+        print prompt
+        $stdin.gets.chomp
+      end
     end
 
     # @return [String]


### PR DESCRIPTION
A suggestion to solve this problem.

Btw, another thing: it would be nice to have a `-g` option to prevent `.riplrc` loading (should that also be done using ENV?)
