### PR TITLE
Symlinked ripl.gemspec to .gemspec for Bundler.

### DIFF
--- a/ripl.gemspec
+++ b/ripl.gemspec
@@ -1,0 +1,1 @@
+.gemspec


### PR DESCRIPTION
Bundler cannot load `.gemspec` files, so I had to symlink `ripl.gemspec` to `.gemspec` so I could bundle Ripl edge.
