### PR TITLE
Make read_history accessible to plugins as write_history

### DIFF
--- a/lib/ripl/history.rb
+++ b/lib/ripl/history.rb
@@ -9,8 +9,7 @@ module Ripl::History
     (@history << super)[-1]
   end
 
-  def before_loop
-    super
+  def read_history
     File.exists?(history_file) &&
       IO.readlines(history_file).each {|e| history << e.chomp }
   end
@@ -18,6 +17,7 @@ module Ripl::History
   def write_history
     File.open(history_file, 'w') {|f| f.write Array(history).join("\n") }
   end
+  def before_loop() read_history end
   def after_loop() write_history end
 end
 Ripl::Shell.include Ripl::History

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -37,6 +37,14 @@ describe "History with readline" do
     shell.history.to_a.should == []
   end
 
+  it "#read_history is accessible to plugins in #before_loop" do
+    mod = Object.const_set "Ping_read_history", Module.new
+    mod.send(:define_method, 'read_history') { @history = ['pong_read_history'] }
+    Shell.send :include, mod
+    shell.before_loop
+    shell.history.should == ['pong_read_history']
+  end
+
   it "#write_history is accessible to plugins in #after_loop" do
     mod = Object.const_set "Ping_write_history", Module.new
     mod.send(:define_method, 'write_history') { @history = ['pong_write_history'] }


### PR DESCRIPTION
I would like to override it in `Ripl::Rc::MultilineHistoryFile` as:

https://github.com/godfat/ripl-rc/blob/5121c889bda85ba6fe3a686c3116dd3dd49261f1/lib/ripl/rc/multiline_history_file.rb#L14

Actually the old code works, but now I have a problem when using `Ripl::Rc::Anchor` together. As you might already know, `Ripl::Rc::Anchor` would create at least another instance of `Ripl::Shell`, which would try to prepare the history from the history file again upon calling `before_loop`. This is not desired.

I can avoid this by overriding `read_history` and check against `history.empty?`, and this check might be also worth considering put into ripl itself. Something like:

``` diff
 def read_history
-  File.exists?(history_file) &&
+  File.exists?(history_file) && history.empty? &&
     IO.readlines(history_file).each {|e| history << e.chomp }
 end
```
