### PR TITLE
Read history only once

### DIFF
--- a/lib/ripl/history.rb
+++ b/lib/ripl/history.rb
@@ -10,7 +10,7 @@ module Ripl::History
   end
 
   def read_history
-    File.exists?(history_file) &&
+    File.exists?(history_file) && history.empty? &&
       IO.readlines(history_file).each {|e| history << e.chomp }
   end
 

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -31,6 +31,15 @@ describe "History with readline" do
     shell.history.to_a.should == %w{check the mike}
   end
 
+  it "#before_loop loads previous history only when it's empty" do
+    File.open(HISTORY_FILE, 'w') {|f| f.write "check\nthe\nmike" }
+    stub(Ripl::Runner).load_rc
+    history = %w{already there}
+    shell.instance_variable_set(:@history, history.dup)
+    shell.before_loop
+    shell.history.to_a.should == history
+  end
+
   it "#before_loop has empty history if no history file exists" do
     stub(Ripl::Runner).load_rc
     shell.before_loop


### PR DESCRIPTION
We might have multiple shells but only one `Readline::HISTORY`,
so only read history when it's empty.
