### PR TITLE
Update deprecated calls to exists? alias

### DIFF
--- a/lib/ripl/history.rb
+++ b/lib/ripl/history.rb
@@ -12,7 +12,7 @@ module Ripl::History
   end
 
   def read_history
-    if ((history_file && File.exists?(history_file)) && history.empty?)
+    if ((history_file && File.exist?(history_file)) && history.empty?)
       IO.readlines(history_file).each {|e| history << e.chomp }
     end
   end

--- a/lib/ripl/runner.rb
+++ b/lib/ripl/runner.rb
@@ -50,7 +50,7 @@ class Ripl::Runner
   end
 
   def self.load_rc(file)
-    load file if File.exists?(File.expand_path(file))
+    load file if File.exist?(File.expand_path(file))
   rescue StandardError, SyntaxError, LoadError
     $stderr.puts "#{app}: #{MESSAGES['load_rc'] % file}:", format_error($!)
   end


### PR DESCRIPTION
![Do I even exists?](https://github.com/cldwalker/ripl/assets/8226466/b497b74f-d333-4dec-98bc-7435389016b4)

You I `exists?` I am afraid the answer is no; not any longer.

Modern versions of ruby have [finally dropped](https://blog.spinthemoose.com/2023/06/02/did-ruby-3-2-2-introduce-breaking-changes/) the long deprecated pluralized alias `exists?` in favor of the preferred `exist?` form.

This PR updates the two usages in the codebase to use the singular (non-deprecated) form. This should work on older versions, since the pluralized form was an alias, but also on new versions of ruby that removed the alias. Everyone wins!

